### PR TITLE
[DEVS-262] chore: update marketplace, connect widget dependencies in configurator

### DIFF
--- a/vue/configurator/src/App.vue
+++ b/vue/configurator/src/App.vue
@@ -10,16 +10,20 @@
 :root {
   background-color: white !important;
 }
+
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  text-align: center;
   color: #2c3e50;
 }
 
 nav {
   padding: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.3rem;
 }
 
 nav a {

--- a/vue/configurator/src/App.vue
+++ b/vue/configurator/src/App.vue
@@ -27,11 +27,16 @@ nav {
 }
 
 nav a {
+  padding: 0.2rem;
   font-weight: bold;
-  color: #2c3e50;
+  color: #42b983;
+  text-decoration: underline;
 }
 
 nav a.router-link-exact-active {
-  color: #42b983;
+  color: #2c3e50;
+  text-decoration: none;
+  font-weight: bolder;
+  background-color: #85d6b26d;
 }
 </style>

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -275,13 +275,17 @@ export default class Configurator extends Vue {
         continue;
       }
       let element = parentElement.firstElementChild;
-      // Set div output text
-      outputDiv.innerText =
-        element?.outerHTML
-          .replace(/id="[a-zA-Z0-9-]*" ?/, "")
-          .replaceAll(/data-v-[a-z0-9]*="" ?/g, "")
-          .replace(" >", ">")
-          .replaceAll("  ", " ") ?? "";
+      if (element) {
+        // clone the element to only get the tag HTML without the children
+        element = element.cloneNode(false) as HTMLElement;
+        // Set div output text
+        outputDiv.innerText =
+          element.outerHTML
+            .replace(/id="[a-zA-Z0-9-]*" ?/, "")
+            .replaceAll(/data-v-[a-z0-9]*="" ?/g, "")
+            .replace(" >", ">")
+            .replaceAll("  ", " ") ?? "";
+      }
     }
   }
 }

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -113,7 +113,7 @@
           :id="`widget-${widgetIndex}`"
           :data-widget="widget.dataWidget"
         ></div>
-        <div v-else :id="`widget-${widgetIndex}`"></div>
+        <!-- NOTE: don't load the other widgets since we're assuming mutation observer pattern -->
       </div>
     </el-main>
   </el-container>
@@ -151,24 +151,18 @@ export interface ConfiguratorDefinition {
           // Clear current widget
           const parentElement = document.getElementById(
             `widget-parent-${index}`
-          )!;
-          let element = parentElement.firstElementChild!;
-          if (element.id !== `widget-${index}`) {
-            // Widget element was fully replaced, so clear out the replacement divs and recreate the original
-            parentElement.innerHTML = "";
-            element = document.createElement("div");
-            element.setAttribute("id", `widget-${index}`);
-            if (widget.dataWidget) {
-              element.setAttribute("data-widget", widget.dataWidget);
-            }
-            parentElement.appendChild(element);
-          } else {
-            // Widget element still exists, reset it
-            element.innerHTML = "";
-            // Set v-node to undefined so it reloads
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            element._vnode = undefined;
+          );
+          if (!parentElement) {
+            continue;
+          }
+          const element =
+            parentElement.firstElementChild || document.createElement("div");
+          element.id = `widget-${index}`;
+          if (
+            widget.dataWidget &&
+            (element as HTMLElement).dataset?.widget !== widget.dataWidget
+          ) {
+            element.setAttribute("data-widget", widget.dataWidget);
           }
 
           // Validate props
@@ -199,7 +193,10 @@ export interface ConfiguratorDefinition {
                 value = value.toString().trim();
               }
               if (value !== prop.defaultValue) {
-                element.setAttribute(propKey, value.toString());
+                // only change if it's different
+                if (value !== element.getAttribute(propKey)) {
+                  element.setAttribute(propKey, value.toString());
+                }
               } else {
                 element.removeAttribute(propKey);
               }
@@ -213,10 +210,18 @@ export interface ConfiguratorDefinition {
                 value = value.toString().trim();
               }
               if (value !== prop.defaultValue) {
-                element.setAttribute(propKey, value.toString());
+                // only change if it's different
+                if (value !== element.getAttribute(propKey)) {
+                  element.setAttribute(propKey, value.toString());
+                }
               } else {
                 element.removeAttribute(propKey);
               }
+            }
+            // NOTE: using mutation observers; mount element only after data-widget is set so that attribute observer
+            // correctly picks up on the node
+            if (!parentElement.firstElementChild) {
+              parentElement.appendChild(element);
             }
           }
 
@@ -256,33 +261,27 @@ export default class Configurator extends Vue {
       document.head.append(link);
     }
     this.updateDivOutput();
-    let timeout = 5;
-    // Trigger widget refresh after 200ms (need to wait for components to render)
-    const mInterval = window.setInterval(() => {
-      timeout--;
-      if (
-        document.querySelectorAll(`div[id^='widget-']`).length ===
-          (this.configuration?.widgets.length ?? 0) * 2 ||
-        timeout === 0
-      ) {
-        clearInterval(mInterval as number);
-        if (timeout !== 0) {
-          window.dispatchEvent(new Event("m-refresh-widgets"));
-        }
-      }
-    }, 1000);
   }
+
+  /**
+   * updates the text of the output div
+   */
   updateDivOutput(): void {
-    for (let index = 0; index < this.configuration!.widgets.length; index++) {
-      const parentElement = document.getElementById(`widget-parent-${index}`)!;
-      let element = parentElement.firstElementChild!;
+    if (!this.configuration) return;
+    for (let index = 0; index < this.configuration.widgets.length; index++) {
+      const parentElement = document.getElementById(`widget-parent-${index}`);
+      const outputDiv = document.getElementById(`div-output-${index}`);
+      if (!parentElement || !outputDiv) {
+        continue;
+      }
+      let element = parentElement.firstElementChild;
       // Set div output text
-      document.getElementById(`div-output-${index}`)!.innerText =
-        element.outerHTML
+      outputDiv.innerText =
+        element?.outerHTML
           .replace(/id="[a-zA-Z0-9-]*" ?/, "")
           .replaceAll(/data-v-[a-z0-9]*="" ?/g, "")
           .replace(" >", ">")
-          .replaceAll("  ", " ");
+          .replaceAll("  ", " ") ?? "";
     }
   }
 }

--- a/vue/configurator/src/config/widgetLocations.ts
+++ b/vue/configurator/src/config/widgetLocations.ts
@@ -4,8 +4,8 @@ interface WidgetLocation {
 }
 
 export const ConnectWidgetLocation: WidgetLocation = {
-  javascript: "https://connect.manifoldxyz.dev/2.0.15/connect.umd.js",
-  css: "https://connect.manifoldxyz.dev/2.0.15/connect.css",
+  javascript: "https://connect.manifoldxyz.dev/2.0.19/connect.umd.js",
+  css: "https://connect.manifoldxyz.dev/2.0.19/connect.css",
 };
 
 export const MarketplaceWidgetLocation: WidgetLocation = {

--- a/vue/configurator/src/views/MarketplaceView.vue
+++ b/vue/configurator/src/views/MarketplaceView.vue
@@ -87,11 +87,11 @@ export default class MarketplaceView extends Vue {
                     label: "Full Listing",
                   },
                   {
-                    value: "m-catalog-card",
+                    value: "m-card-catalog",
                     label: "Catalog Card",
                   },
                   {
-                    value: "m-countdown-card",
+                    value: "m-card-countdown",
                     label: "Countdown Card",
                   },
                 ],

--- a/vue/configurator/src/views/MarketplaceView.vue
+++ b/vue/configurator/src/views/MarketplaceView.vue
@@ -13,6 +13,16 @@ import {
   MarketplaceWidgetLocation,
 } from "@/config/widgetLocations";
 
+declare global {
+  interface WindowEventMap {
+    "m-marketplace_widget_injected": CustomEvent<{
+      contractAddress: string;
+      listingId: string;
+      key: string;
+    }>;
+  }
+}
+
 @Options({
   components: {
     Configurator,
@@ -105,11 +115,37 @@ export default class MarketplaceView extends Vue {
                 defaultValue: "",
                 required: true,
               },
+              "data-widget-key": {
+                name: "Widget Key",
+                type: WidgetPropType.STRING,
+                value: "",
+                defaultValue: "",
+                required: false,
+              },
             },
           },
         ],
       },
     };
+  }
+
+  mounted() {
+    window.addEventListener(
+      "m-marketplace_widget_injected",
+      this.onMarketplaceWidgetInjected
+    );
+  }
+
+  beforeUnmount(): void {
+    window.removeEventListener(
+      "m-marketplace_widget_injected",
+      this.onMarketplaceWidgetInjected
+    );
+  }
+
+  onMarketplaceWidgetInjected(event: CustomEvent) {
+    const { detail } = event;
+    console.log("Marketplace Widget Injected", detail);
   }
 }
 </script>


### PR DESCRIPTION
## changes
- since marketplace is always pointing to latest, update the `card` `data-widget` names
- update connect widget so that the injection logic also uses mutation observer
- update configurator logic to rely on the mutation observer (remove refresh event)
- make output div display only the outside tag's HTML (not the children)
- small style changes

## linear
https://linear.app/manifoldxyz/issue/DEVS-282/

## screenshots

### before
<img width="888" alt="Screen Shot 2022-12-23 at 12 28 18 PM" src="https://user-images.githubusercontent.com/11150920/209376531-e4cac7dc-0968-40b8-8d7f-ffe2e45dbbd6.png">

### after
![282-fixed-reload](https://user-images.githubusercontent.com/11150920/209376827-a36efeb0-f5f9-4e2d-90b4-66f47bd475cd.gif)
