### PR TITLE
Milestone 2: Adding data-media-background prop

### DIFF
--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -68,6 +68,47 @@
               v-model="prop.value"
               size="large"
             />
+            <!-- data-media-background has a type of JSON string -->
+            <el-row
+              v-else-if="prop.type === WidgetPropType.INTERFACE"
+              style="
+                align-items: center;
+                border-color: lightgrey;
+                border-style: solid;
+                border-width: thin;
+                border-radius: 5px;
+                height: 150px;
+                width: 250px;
+              "
+            >
+              <el-row v-for="(config, key) in prop.value" :key="key">
+                <el-input
+                  v-if="config.type === WidgetPropType.STRING"
+                  v-model="config.value"
+                  class="w-50 m-2"
+                  :placeholder="key"
+                />
+                <el-select
+                  v-else-if="config.type === WidgetPropType.ENUMERATION"
+                  v-model="config.value"
+                  class="m-2"
+                  placeholder="None"
+                  size="small"
+                >
+                  <el-option
+                    v-for="item in config.options"
+                    :key="item.value"
+                    :label="item.label"
+                    :value="item.value"
+                  />
+                </el-select>
+                <el-checkbox
+                  v-else-if="config.type === WidgetPropType.BOOLEAN"
+                  v-model="config.value"
+                  size="large"
+                />
+              </el-row>
+            </el-row>
           </el-col>
         </el-row>
       </div>
@@ -191,6 +232,17 @@ export interface ConfiguratorDefinition {
               let value = prop.value;
               if (prop.type === WidgetPropType.STRING) {
                 value = value.toString().trim();
+              }
+              if (prop.type === WidgetPropType.INTERFACE) {
+                const mediabackground = Object.fromEntries(
+                  Object.entries(value).map(([k, v]) => [k, v.value])
+                );
+                // let mediabackground = {};
+                // Object.keys(value).forEach((config) => {
+                //   mediabackground.config =
+                // })
+                // value = JSON.stringify(value);
+                value = JSON.stringify(mediabackground);
               }
               if (value !== prop.defaultValue) {
                 // only change if it's different

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -374,11 +374,6 @@ export default class Configurator extends Vue {
             .replaceAll(/data-v-[a-z0-9]*="" ?/g, "")
             .replace(" >", ">")
             .replaceAll("  ", " ") ?? "";
-        // Replace all instances of HTML entity &quot; with `"`
-        // When a JSON object is JSON.stringify(), HTML text will encode double quotes to avoid misinterpretation
-        // Converting this back to double quotes solves user issue's with directly copy pasting the div element
-        // https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
-        outputDiv.innerText = outputDiv.innerText.replaceAll("&quot;", '"');
       }
     }
   }

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -71,15 +71,7 @@
             <!-- data-media-background has a type of JSON string -->
             <el-row
               v-else-if="prop.type === WidgetPropType.INTERFACE"
-              style="
-                align-items: center;
-                border-color: lightgrey;
-                border-style: solid;
-                border-width: thin;
-                border-radius: 5px;
-                height: 150px;
-                width: 250px;
-              "
+              class="prop-groupings"
             >
               <el-row v-for="(config, key) in prop.value" :key="key">
                 <!-- config needs to be confirmed as an object for it to have properties like 'type' since
@@ -100,7 +92,7 @@
                     config?.type === WidgetPropType.ARRAY
                   "
                 >
-                  <label id="multipleInputs"> colors example: red, blue </label>
+                  <label> colors example: red, blue </label>
                   <el-input
                     v-model="config.value"
                     class="w-50 m-2"
@@ -386,7 +378,15 @@ export default class Configurator extends Vue {
   margin-top: 20px;
   margin-bottom: 10px;
 }
-
+.prop-groupings {
+  align-items: center;
+  border-color: lightgrey;
+  border-style: solid;
+  border-width: thin;
+  border-radius: 5px;
+  height: 150px;
+  width: 250px;
+}
 .code-blocks {
   text-align: left;
 }
@@ -397,7 +397,6 @@ export default class Configurator extends Vue {
 .code-blocks h2 {
   margin-top: 5px;
 }
-
 .widget-configuration {
   text-align: left;
 }
@@ -410,7 +409,7 @@ export default class Configurator extends Vue {
   word-wrap: break-word;
   overflow: auto;
 }
-label[id="multipleInputs"] {
+label {
   font-size: 12px;
   margin-bottom: 20px;
   color: rgba(97, 91, 91, 0.521);

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -195,7 +195,6 @@ import {
   WidgetPropDefinition,
 } from "./lib/WidgetProps";
 import _ from "lodash";
-import { placeholder } from "@babel/types";
 
 interface ConfiguratorData {
   WidgetPropType: any;

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -269,7 +269,7 @@ export interface ConfiguratorDefinition {
                       // Make sure to not split by commas that are contained in RGB(A)/HSL(A) CSS values.
                       return [
                         k,
-                        v.value.includes("rgb(") || v.value.includes("hsl(")
+                        v.value.includes("rgb") || v.value.includes("hsl")
                           ? v.value.split(/,(?![^()]*\))/)
                           : v.value.endsWith(",")
                           ? v.value.slice(0, -1).split(",")

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -100,9 +100,7 @@
                     config?.type === WidgetPropType.ARRAY
                   "
                 >
-                  <label id="multipleInputs">
-                    Enter one or more options seperated by a comma
-                  </label>
+                  <label id="multipleInputs"> colors example: red, blue </label>
                   <el-input
                     v-model="config.value"
                     class="w-50 m-2"
@@ -415,7 +413,8 @@ export default class Configurator extends Vue {
   overflow: auto;
 }
 label[id="multipleInputs"] {
-  font-size: 11px;
+  font-size: 12px;
   margin-bottom: 20px;
+  color: rgba(97, 91, 91, 0.521);
 }
 </style>

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -83,13 +83,13 @@
             >
               <el-row v-for="(config, key) in prop.value" :key="key">
                 <el-input
-                  v-if="config.type === WidgetPropType.STRING"
+                  v-if="config?.type === WidgetPropType.STRING"
                   v-model="config.value"
                   class="w-50 m-2"
                   :placeholder="key"
                 />
                 <el-select
-                  v-else-if="config.type === WidgetPropType.ENUMERATION"
+                  v-else-if="config?.type === WidgetPropType.ENUMERATION"
                   v-model="config.value"
                   class="m-2"
                   placeholder="None"
@@ -103,7 +103,7 @@
                   />
                 </el-select>
                 <el-checkbox
-                  v-else-if="config.type === WidgetPropType.BOOLEAN"
+                  v-else-if="config?.type === WidgetPropType.BOOLEAN"
                   v-model="config.value"
                   size="large"
                 />
@@ -330,6 +330,10 @@ export default class Configurator extends Vue {
       if (element) {
         // clone the element to only get the tag HTML without the children
         element = element.cloneNode(false) as HTMLElement;
+        let dataMediaBackground = element.getAttribute(`data-media-background`);
+        // if (dataMediaBackground) {
+        //   outputDiv.innerText = dataMediaBackground.replace(/"/g, '&quot');
+        // }
         // Set div output text
         outputDiv.innerText =
           element.outerHTML
@@ -337,6 +341,11 @@ export default class Configurator extends Vue {
             .replaceAll(/data-v-[a-z0-9]*="" ?/g, "")
             .replace(" >", ">")
             .replaceAll("  ", " ") ?? "";
+        // Replace all instances of HTML entity &quot; with `"`
+        // When a JSON object is JSON.stringify(), HTML text will encode double quotes to avoid misinterpretation
+        // Converting this back to double quotes solves user issue's with directly copy pasting the div element
+        // https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references
+        outputDiv.innerText = outputDiv.innerText.replaceAll("&quot;", '"');
       }
     }
   }

--- a/vue/configurator/src/components/Configurator.vue
+++ b/vue/configurator/src/components/Configurator.vue
@@ -266,9 +266,12 @@ export interface ConfiguratorDefinition {
                   Object.entries(value).map(([k, v]) => {
                     if (v.type === WidgetPropType.ARRAY) {
                       // Splitting colors given into an array of colors. If user ends string with a "," the empty element is removed
+                      // Make sure to not split by commas that are contained in RGB(A)/HSL(A) CSS values.
                       return [
                         k,
-                        v.value.endsWith(",")
+                        v.value.includes("rgb(") || v.value.includes("hsl(")
+                          ? v.value.split(/,(?![^()]*\))/)
+                          : v.value.endsWith(",")
                           ? v.value.slice(0, -1).split(",")
                           : v.value.split(","),
                       ];

--- a/vue/configurator/src/components/lib/WidgetProps.ts
+++ b/vue/configurator/src/components/lib/WidgetProps.ts
@@ -2,6 +2,23 @@ export enum WidgetPropType {
   STRING = "string",
   BOOLEAN = "boolean",
   ENUMERATION = "enumeration",
+  INTERFACE = "interface",
+  ARRAY = "array",
+}
+
+export interface MediaBackgroundConfig {
+  /** angle in degrees representing from which direction the gradient (linear/conic) flows */
+  // Number
+  angle?: WidgetPropType;
+  /** string array of colors for the media background */
+  // string[]
+  colors?: WidgetPropType;
+  /** URI to the background image. takes precedence over the background color/gradient */
+  // string
+  image?: WidgetPropType;
+  /** if two or more color values are provided, specifies the type of background */
+  // enumeration of "linear" | "conic" | "radial"
+  type?: WidgetPropType;
 }
 
 interface WidgetPropOptions {
@@ -12,7 +29,7 @@ interface WidgetPropOptions {
 export interface WidgetPropDefinition {
   name: string;
   type: WidgetPropType;
-  value: string | boolean;
+  value: string | boolean | number | MediaBackgroundConfig;
   defaultValue: string | boolean;
   options?: WidgetPropOptions[];
   required?: boolean;

--- a/vue/configurator/src/components/lib/WidgetProps.ts
+++ b/vue/configurator/src/components/lib/WidgetProps.ts
@@ -9,16 +9,16 @@ export enum WidgetPropType {
 export interface MediaBackgroundConfig {
   /** angle in degrees representing from which direction the gradient (linear/conic) flows */
   // Number
-  angle?: WidgetPropType;
+  angle?: WidgetPropDefinition;
   /** string array of colors for the media background */
   // string[]
-  colors?: WidgetPropType;
+  colors?: WidgetPropDefinition;
   /** URI to the background image. takes precedence over the background color/gradient */
   // string
-  image?: WidgetPropType;
+  image?: WidgetPropDefinition;
   /** if two or more color values are provided, specifies the type of background */
   // enumeration of "linear" | "conic" | "radial"
-  type?: WidgetPropType;
+  type?: WidgetPropDefinition;
 }
 
 interface WidgetPropOptions {
@@ -29,7 +29,7 @@ interface WidgetPropOptions {
 export interface WidgetPropDefinition {
   name: string;
   type: WidgetPropType;
-  value: string | boolean | number | MediaBackgroundConfig;
+  value: string | boolean | MediaBackgroundConfig;
   defaultValue: string | boolean;
   options?: WidgetPropOptions[];
   required?: boolean;

--- a/vue/configurator/src/components/lib/WidgetProps.ts
+++ b/vue/configurator/src/components/lib/WidgetProps.ts
@@ -30,7 +30,7 @@ export interface WidgetPropDefinition {
   name: string;
   type: WidgetPropType;
   value: string | boolean | MediaBackgroundConfig;
-  defaultValue: string | boolean;
+  defaultValue: string | boolean | MediaBackgroundConfig;
   options?: WidgetPropOptions[];
   required?: boolean;
   dependentProps?: string[];

--- a/vue/configurator/src/views/MarketplaceView.vue
+++ b/vue/configurator/src/views/MarketplaceView.vue
@@ -132,7 +132,6 @@ export default class MarketplaceView extends Vue {
                   colors: {
                     name: "colors",
                     type: WidgetPropType.ARRAY,
-                    // Testing with hard coded values
                     value: "",
                     defaultValue: [],
                   },

--- a/vue/configurator/src/views/MarketplaceView.vue
+++ b/vue/configurator/src/views/MarketplaceView.vue
@@ -35,7 +35,7 @@ export default class MarketplaceView extends Vue {
           "data-network": {
             name: "Network",
             type: WidgetPropType.ENUMERATION,
-            value: "1",
+            value: "5",
             options: [
               {
                 value: "1",
@@ -87,7 +87,7 @@ export default class MarketplaceView extends Vue {
               "data-widget": {
                 name: "Widget Type",
                 type: WidgetPropType.ENUMERATION,
-                value: "",
+                value: "m-layout-complete-listing",
                 options: [
                   {
                     value: "m-layout-complete-listing",
@@ -108,7 +108,7 @@ export default class MarketplaceView extends Vue {
               "data-id": {
                 name: "Listing Id",
                 type: WidgetPropType.STRING,
-                value: "",
+                value: "367",
                 defaultValue: "",
                 required: true,
               },
@@ -117,6 +117,45 @@ export default class MarketplaceView extends Vue {
                 type: WidgetPropType.STRING,
                 value: "",
                 defaultValue: "",
+                required: false,
+              },
+              "data-media-background": {
+                name: "Background Media",
+                type: WidgetPropType.INTERFACE,
+                value: {
+                  angle: {
+                    type: WidgetPropType.STRING,
+                    value: "",
+                  },
+                  colors: {
+                    type: WidgetPropType.STRING,
+                    // Testing with hard coded values
+                    value: ["red", "blue"],
+                  },
+                  image: {
+                    type: WidgetPropType.STRING,
+                    value: "",
+                  },
+                  type: {
+                    type: WidgetPropType.ENUMERATION,
+                    value: "",
+                    options: [
+                      {
+                        value: "linear",
+                        label: "Linear",
+                      },
+                      {
+                        value: "conic",
+                        label: "Conic",
+                      },
+                      {
+                        value: "radial",
+                        label: "Radial",
+                      },
+                    ],
+                  },
+                },
+                defaultValue: {},
                 required: false,
               },
             },

--- a/vue/configurator/src/views/MarketplaceView.vue
+++ b/vue/configurator/src/views/MarketplaceView.vue
@@ -35,7 +35,7 @@ export default class MarketplaceView extends Vue {
           "data-network": {
             name: "Network",
             type: WidgetPropType.ENUMERATION,
-            value: "5",
+            value: "1",
             options: [
               {
                 value: "1",
@@ -87,7 +87,7 @@ export default class MarketplaceView extends Vue {
               "data-widget": {
                 name: "Widget Type",
                 type: WidgetPropType.ENUMERATION,
-                value: "m-layout-complete-listing",
+                value: "",
                 options: [
                   {
                     value: "m-layout-complete-listing",
@@ -108,7 +108,7 @@ export default class MarketplaceView extends Vue {
               "data-id": {
                 name: "Listing Id",
                 type: WidgetPropType.STRING,
-                value: "367",
+                value: "",
                 defaultValue: "",
                 required: true,
               },

--- a/vue/configurator/src/views/MarketplaceView.vue
+++ b/vue/configurator/src/views/MarketplaceView.vue
@@ -124,19 +124,26 @@ export default class MarketplaceView extends Vue {
                 type: WidgetPropType.INTERFACE,
                 value: {
                   angle: {
+                    name: "angle",
                     type: WidgetPropType.STRING,
                     value: "",
+                    defaultValue: "",
                   },
                   colors: {
-                    type: WidgetPropType.STRING,
+                    name: "colors",
+                    type: WidgetPropType.ARRAY,
                     // Testing with hard coded values
-                    value: ["red", "blue"],
+                    value: "",
+                    defaultValue: [],
                   },
                   image: {
+                    name: "image",
                     type: WidgetPropType.STRING,
                     value: "",
+                    defaultValue: "",
                   },
                   type: {
+                    name: "type",
                     type: WidgetPropType.ENUMERATION,
                     value: "",
                     options: [


### PR DESCRIPTION
## Milestone 2: Adding the page-color-scheme


- Added the property data-media-background that takes the JSON object MediaBackgroundConfig
- Added MediaBackgroundConfig and its values to MarketplaceView
- Created a group of fields on the Configurator for the data-media-background attribute
- Users can test an image, colors (or multiple), and gradient types and angles

### Edge Cases tested:
- an Image URI should take precedence over colors
- if image URI is broken/wrong, fallback color takes over
- if no gradient type is selected and there is multiple colors, no background is used (assumed expected behavior)
- Changing angle or gradient type has no effect on single color or image backgrounds

Here is an example of an image
![image](https://user-images.githubusercontent.com/67350995/230846584-0b4d770f-6735-4a0a-8b09-b92d8d621847.png)

Here is an example of a singular color:
![image](https://user-images.githubusercontent.com/67350995/230847045-8a03626a-9e7b-4f89-aa19-e4b5eae8aee4.png)

Here is an example of gradient colors:
![image](https://user-images.githubusercontent.com/67350995/230846945-27b73c4a-88bf-4191-afb9-364c48e941bd.png)

Here is an example of gradient colors using other CSS valid values:
![image](https://user-images.githubusercontent.com/67350995/230854728-35ec5fa4-e8fd-4d6a-a9c4-69304d3ee0ec.png)

